### PR TITLE
Further ignore IDEA-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ nohup.out
 jredis.log
 .idea
 *.iml
+*.ipr
+*.iws


### PR DESCRIPTION
Currently the project ignores .idea (directory-based format) as well
as *.ims (file-based format) but not *.ipr and *.iws.  We thus ignore
the latter two as they are generated by IDEA as well.

Signed-off-by: Ealden Esto E. Escanan ealden@gmail.com
