### PR TITLE
Set Log4J dependency from runtime to compile in log4j module as we are re

### DIFF
--- a/log4j/pom.xml
+++ b/log4j/pom.xml
@@ -121,7 +121,6 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.16</version>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
@@ -208,4 +207,3 @@
 	</distributionManagement>
 
 </project>
-	


### PR DESCRIPTION
Set Log4J dependency from runtime to compile in log4j module as we are referencing org.apache.log4j.Level in our code

We are getting compile errors in the log4j module, as it has the Log4J
dependency set to runtime but is referencing org.apache.log4j.Level in
the code.  Changing the dependency to compile (removing <scope />) fixes
this problem, as the dependency is now available during compile time
where it is needed.

Alternatively, all references to org.apache.log4j.Level could be removed,
which should allow us to put the log4j dependency back to runtime.  Such
change is not covered in this patch.

Signed-off-by: Ealden Esto E. Escanan ealden@gmail.com
