### PR TITLE
Upgrade to spring-boot 1.4.0

### DIFF
--- a/rabbitmq-tutorials/pom.xml
+++ b/rabbitmq-tutorials/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.1.RELEASE</version>
+		<version>1.4.0.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
Spring Boot 1.3.x won't work with spring-rabbit-1.6.0

`java.lang.NoSuchMethodError: org.springframework.amqp.core.MessageProperties.getCorrelationIdString()Ljava/lang/String;
at org.springframework.amqp.rabbit.support.DefaultMessagePropertiesConverter.fromMessageProperties(DefaultMessagePropertiesConverter.java:183) ~[spring-rabbit-1.6.0.RELEASE.jar!/:na]`