### PR TITLE
Updated spring-boot version

### DIFF
--- a/stocks/pom.xml
+++ b/stocks/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.samples.spring</groupId>
 	<artifactId>spring-rabbit-stocks</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.1.BUILD-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>Spring Rabbit Stocks</name>
 	<url>http://www.springframework.org</url>
@@ -15,7 +15,7 @@
 	</description>
 	<properties>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
-		<spring.framework.version>3.2.0.BUILD-SNAPSHOT</spring.framework.version>
+		<spring.framework.version>4.2.5.RELEASE</spring.framework.version>
 		<spring.amqp.version>1.0.0.RELEASE</spring.amqp.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
I've received this error message, so I updated the POM to compile with the same spring version from master branch

[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Spring Rabbit Stocks 1.0.0.BUILD-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for org.springframework:spring-test:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[WARNING] The POM for org.springframework:spring-context-support:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[WARNING] The POM for org.springframework:spring-aop:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[WARNING] The POM for org.springframework:spring-oxm:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[WARNING] The POM for org.springframework:spring-tx:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[WARNING] The POM for org.springframework:spring-webmvc:jar:3.2.0.BUILD-SNAPSHOT is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.284 s
[INFO] Finished at: 2017-04-14T21:49:10-03:00
[INFO] Final Memory: 7M/236M
