### PR TITLE
URL Cleanup

### DIFF
--- a/helloworld/pom.xml
+++ b/helloworld/pom.xml
@@ -8,7 +8,7 @@
 	<version>2.1.3.RELEASE</version>
 	<packaging>jar</packaging>
 	<name>Spring AMQP Hello World</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>
 		<![CDATA[
       This project shows the usage of Spring AMQP integration classes.
@@ -183,14 +183,14 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>Codehaus</id>
-			<url>http://repository.codehaus.org/</url>
+			<url>https://repository.codehaus.org/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<distributionManagement>
-		<downloadUrl>http://www.springframework.org/download</downloadUrl>
+		<downloadUrl>https://www.springframework.org/download</downloadUrl>
 		<site>
 			<id>staging</id>
 			<url>file:///${user.dir}/target/staging/org.springframework.batch.archetype/${project.artifactId}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,13 @@
 		</profile>
 	</profiles>
 	<scm>
-		<url>http://github.com/SpringSource/spring-amqp-samples</url>
+		<url>https://github.com/SpringSource/spring-amqp-samples</url>
 		<connection>scm:git:git://github.com/SpringSource/spring-amqp-samples.git</connection>
 		<developerConnection>scm:git:git://github.com/SpringSource/spring-amqp-samples.git</developerConnection>
 	</scm>
 	<distributionManagement>
 		<!-- see 'staging' profile for dry-run deployment settings -->
-		<downloadUrl>http://github.com/SpringSource/spring-amqp-samples</downloadUrl>
+		<downloadUrl>https://github.com/SpringSource/spring-amqp-samples</downloadUrl>
 		<site>
 			<id>spring-site</id>
 			<url>scp://static.springframework.org/var/www/domains/springframework.org/static/htdocs/spring-amqp/docs/${project.version}</url>

--- a/spring-rabbit-confirms-returns/mvnw
+++ b/spring-rabbit-confirms-returns/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-rabbit-confirms-returns/mvnw.cmd
+++ b/spring-rabbit-confirms-returns/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-rabbit-global-errorhandler/mvnw
+++ b/spring-rabbit-global-errorhandler/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-rabbit-global-errorhandler/mvnw.cmd
+++ b/spring-rabbit-global-errorhandler/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/spring-rabbit-json/mvnw
+++ b/spring-rabbit-json/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/spring-rabbit-json/mvnw.cmd
+++ b/spring-rabbit-json/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/stocks/pom.xml
+++ b/stocks/pom.xml
@@ -7,7 +7,7 @@
 	<version>2.1.3.RELEASE</version>
 	<packaging>war</packaging>
 	<name>Spring Rabbit Stocks</name>
-	<url>http://www.spring.io</url>
+	<url>https://www.spring.io</url>
 	<description>
 		<![CDATA[
       This project shows the usage of Spring Rabbit integration classes.
@@ -218,14 +218,14 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>Codehaus</id>
-			<url>http://repository.codehaus.org/</url>
+			<url>https://repository.codehaus.org/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
 	<distributionManagement>
-		<downloadUrl>http://www.springframework.org/download</downloadUrl>
+		<downloadUrl>https://www.springframework.org/download</downloadUrl>
 		<site>
 			<id>staging</id>
 			<url>file:///${user.dir}/target/staging/org.springframework.batch.archetype/${project.artifactId}</url>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repository.codehaus.org/ (UnknownHostException) migrated to:  
  https://repository.codehaus.org/ ([https](https://repository.codehaus.org/) result UnknownHostException).
* http://www.springframework.org/download (404) migrated to:  
  https://www.springframework.org/download ([https](https://www.springframework.org/download) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://github.com/SpringSource/spring-amqp-samples migrated to:  
  https://github.com/SpringSource/spring-amqp-samples ([https](https://github.com/SpringSource/spring-amqp-samples) result 301).
* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance