### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-This project hosts some samples that complement [Spring AMQP](http://github.com/SpringSource/spring-amqp), showing you how to get started with Spring and AMQP.
+This project hosts some samples that complement [Spring AMQP](https://github.com/SpringSource/spring-amqp), showing you how to get started with Spring and AMQP.
 
 # Build Instructions #
 
-Install the [RabbitMQ](http://www.rabbitmq.com) broker first (version
+Install the [RabbitMQ](https://www.rabbitmq.com) broker first (version
 2.3.1 or better).  Then clone from GIT and then use Maven (2.1.*):
 
     $ git clone ...
@@ -43,7 +43,7 @@ broker.
 
 ## RabbitMQ Tutorials
 
-Spring Boot versions of the [6 standard RabbitMQ tutorials](http://www.rabbitmq.com/getstarted.html) are provided in `rabbitmq-tutorials`.
+Spring Boot versions of the [6 standard RabbitMQ tutorials](https://www.rabbitmq.com/getstarted.html) are provided in `rabbitmq-tutorials`.
 
 ## Spring Boot Applications
 
@@ -54,10 +54,10 @@ Explore their individual READMEs for more information.
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](http://forum.springsource.org/forumdisplay.php?f=74) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [forum](https://forum.spring.io/forumdisplay.php?f=74) by responding to questions and joining the debate.
 * Create [JIRA](https://jira.springsource.org/browse/AMQP) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Refer to the spring-amqp [Contributor's Guidelines](https://github.com/spring-projects/spring-amqp/blob/master/CONTRIBUTING.adoc) for complete information about the necessary steps.
 

--- a/log4j/src/main/resources/static/js/jquery.min.js
+++ b/log4j/src/main/resources/static/js/jquery.min.js
@@ -1,13 +1,13 @@
 /*!
  * jQuery JavaScript Library v1.4.4
- * http://jquery.com/
+ * https://jquery.com/
  *
  * Copyright 2010, John Resig
  * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Includes Sizzle.js
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  * Copyright 2010, The Dojo Foundation
  * Released under the MIT, BSD, and GPL Licenses.
  *

--- a/log4j/src/main/resources/static/js/jquery.mustache.js
+++ b/log4j/src/main/resources/static/js/jquery.mustache.js
@@ -2,7 +2,7 @@
 Shameless port of a shameless port
 @defunkt => @janl => @aq
  
-See http://github.com/defunkt/mustache for more info.
+See https://github.com/defunkt/mustache for more info.
 */
  
 ;(function($) {
@@ -10,7 +10,7 @@ See http://github.com/defunkt/mustache for more info.
 /*
   mustache.js — Logic-less templates in JavaScript
 
-  See http://mustache.github.com/ for more info.
+  See https://mustache.github.com/ for more info.
 */
 
 var Mustache = function() {

--- a/log4j/src/main/webapp/index.jsp
+++ b/log4j/src/main/webapp/index.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Spring AMQP Log4J Demo</title>
@@ -173,7 +173,7 @@
 					<a href="" title="Site Name" rel="home"> Spring AMQP Log4J Demo</a>
 				</div>
 				<div id='company-name'>
-					<a href="http://www.springsource.org/spring-amqp"
+					<a href="https://www.springsource.org/spring-amqp"
 						title="Spring AMQP"> Spring AMQP Home</a>
 				</div>
 			</div>
@@ -210,9 +210,9 @@
 
 			<div id="content" class="no-side-nav">
 				This application is a the "log4j" sample from <a
-					href="http://github.com/SpringSource/spring-amqp">Spring AMQP</a>.
+					href="https://github.com/SpringSource/spring-amqp">Spring AMQP</a>.
 				You can get the source code from the <a
-					href="http://github.com/SpringSource/spring-amqp-samples">Spring
+					href="https://github.com/SpringSource/spring-amqp-samples">Spring
 					AMQP Samples</a> project on Github.
 
 				<h1 id="routingHeader">Routing Key</h1>

--- a/stocks/src/main/resources/static/js/jquery.min.js
+++ b/stocks/src/main/resources/static/js/jquery.min.js
@@ -1,13 +1,13 @@
 /*!
  * jQuery JavaScript Library v1.4.4
- * http://jquery.com/
+ * https://jquery.com/
  *
  * Copyright 2010, John Resig
  * Dual licensed under the MIT or GPL Version 2 licenses.
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Includes Sizzle.js
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  * Copyright 2010, The Dojo Foundation
  * Released under the MIT, BSD, and GPL Licenses.
  *

--- a/stocks/src/main/resources/static/js/jquery.mustache.js
+++ b/stocks/src/main/resources/static/js/jquery.mustache.js
@@ -2,7 +2,7 @@
 Shameless port of a shameless port
 @defunkt => @janl => @aq
  
-See http://github.com/defunkt/mustache for more info.
+See https://github.com/defunkt/mustache for more info.
 */
  
 ;(function($) {
@@ -10,7 +10,7 @@ See http://github.com/defunkt/mustache for more info.
 /*
   mustache.js — Logic-less templates in JavaScript
 
-  See http://mustache.github.com/ for more info.
+  See https://mustache.github.com/ for more info.
 */
 
 var Mustache = function() {

--- a/stocks/src/main/webapp/index.jsp
+++ b/stocks/src/main/webapp/index.jsp
@@ -1,6 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>Spring AMQP Stocks Demo</title>
@@ -131,7 +131,7 @@
 						Demo</a>
 				</div>
 				<div id='company-name'>
-					<a href="http://www.springsource.org/spring-amqp"
+					<a href="https://www.springsource.org/spring-amqp"
 						title="Spring AMQP"> Spring AMQP Home</a>
 				</div>
 			</div>
@@ -141,9 +141,9 @@
 		<div id="container">
 			<div id="content" class="no-side-nav">
 				This application is a the "stocks" sample from <a
-					href="http://github.com/SpringSource/spring-amqp">Spring AMQP</a>.
+					href="https://github.com/SpringSource/spring-amqp">Spring AMQP</a>.
 				You can get the source code from the <a
-					href="http://github.com/SpringSource/spring-amqp-samples">Spring
+					href="https://github.com/SpringSource/spring-amqp-samples">Spring
 					AMQP Samples</a> project on Github.
 				<h1>Deal</h1>
 				<c:choose>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result ReadTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://jquery.com/ with 2 occurrences migrated to:  
  https://jquery.com/ ([https](https://jquery.com/) result 200).
* [ ] http://sizzlejs.com/ with 2 occurrences migrated to:  
  https://sizzlejs.com/ ([https](https://sizzlejs.com/) result 200).
* [ ] http://www.rabbitmq.com with 1 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* [ ] http://www.rabbitmq.com/getstarted.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/getstarted.html ([https](https://www.rabbitmq.com/getstarted.html) result 200).
* [ ] http://forum.springsource.org/forumdisplay.php?f=74 (301) with 1 occurrences migrated to:  
  https://forum.spring.io/forumdisplay.php?f=74 ([https](https://forum.springsource.org/forumdisplay.php?f=74) result 301).
* [ ] http://github.com/SpringSource/spring-amqp with 3 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp ([https](https://github.com/SpringSource/spring-amqp) result 301).
* [ ] http://github.com/SpringSource/spring-amqp-samples with 2 occurrences migrated to:  
  https://github.com/SpringSource/spring-amqp-samples ([https](https://github.com/SpringSource/spring-amqp-samples) result 301).
* [ ] http://github.com/defunkt/mustache with 2 occurrences migrated to:  
  https://github.com/defunkt/mustache ([https](https://github.com/defunkt/mustache) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://jquery.org/license with 2 occurrences migrated to:  
  https://jquery.org/license ([https](https://jquery.org/license) result 301).
* [ ] http://mustache.github.com/ with 2 occurrences migrated to:  
  https://mustache.github.com/ ([https](https://mustache.github.com/) result 301).
* [ ] http://www.springsource.org/spring-amqp with 2 occurrences migrated to:  
  https://www.springsource.org/spring-amqp ([https](https://www.springsource.org/spring-amqp) result 301).
* [ ] http://www.springsource.org/node/feed with 1 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 2 occurrences
* http://www.springframework.org/tags/form with 2 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences