### PR TITLE
Fixes: #60 - spring rabbit stocks web-app doesn't work

### DIFF
--- a/stocks/pom.xml
+++ b/stocks/pom.xml
@@ -64,21 +64,20 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-			<version>1.1.2</version>
+			<groupId>org.apache.taglibs</groupId>
+			<artifactId>taglibs-standard-spec</artifactId>
+			<version>1.2.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<artifactId>standard</artifactId>
-			<groupId>taglibs</groupId>
-			<version>1.1.2</version>
-			<type>jar</type>
+			<groupId>org.apache.taglibs</groupId>
+			<artifactId>taglibs-standard-impl</artifactId>
+			<version>1.2.5</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -158,9 +157,9 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
-				<groupId>org.mortbay.jetty</groupId>
-				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.26</version>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
+				<version>9.4.24.v20191120</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/stocks/src/main/webapp/WEB-INF/web.xml
+++ b/stocks/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="
-			http://java.sun.com/xml/ns/j2ee
-			https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-	version="2.4">
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+		 version="3.1">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>


### PR DESCRIPTION
Note: I have upgraded jetty-maven-plugin to 9.4.24.v20191120, that is the latest version working in spring-rabbit-stocks.
More recent versions return an EOF error when hitting http://localhost:8080, but I currently have no idea how to solve it. 

@pivotal-issuemaster This is an Obvious Fix

Resolves https://github.com/spring-projects/spring-amqp-samples/issues/60